### PR TITLE
improve hamburger visibility #1

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -56,7 +56,7 @@ p.lead {
     font-family: 'Open Sans';
 }
 
-.ug-badge { 
+.ug-badge {
     width: 50px;
 }
 /* Links */
@@ -102,7 +102,7 @@ a:hover {
     /* add drop shadow here */
     display: inline-block;
     padding: 15px;
-    margin-right: 25px; 
+    margin-right: 25px;
     color: #fff;
     font-family: 'Roboto Condensed';
     /*font-weight: bold;*/
@@ -125,7 +125,10 @@ a:hover {
 }
 .sub-menu > a:hover {
     text-decoration: none;
-    color: #000;
+    color: #ffffff;
+}
+#menuControl{
+  background-color: #68227b
 }
 .main-content-slide {
     position: relative;
@@ -182,5 +185,3 @@ a:hover {
     width: 100%;
     text-decoration: none;
 }
-
-


### PR DESCRIPTION
Give the hamburger menu a small background, with the same purple as the .net square in the center. On hover switch to white.

![getdotnet](https://cloud.githubusercontent.com/assets/3459800/10707002/cb1ed26e-79ba-11e5-8ce9-cef98975ee03.PNG)
