### PR TITLE
More fixes for the supported paltforms

### DIFF
--- a/install-dotnet.html
+++ b/install-dotnet.html
@@ -47,7 +47,7 @@
         </div>
         <div class="row">
           <div class="col-md-12">
-              <h2>Available .NET Versions</h2>
+              <h2>Popular .NET Versions</h2>
               <!--<ul id="versions" class="list-group"></ul>-->
               <div id="versionsList"></div>
             </div>
@@ -66,7 +66,8 @@ document.title = "Install .NET Framework Versions";
 $(document).ready(function() {
     var data;
     //var json = "platforms.json";
-    var json = "https://dotnetweb.blob.core.windows.net/platforms/platforms.json";
+    // var json = "https://dotnetweb.blob.core.windows.net/platforms/platforms.json";
+    var json = "https://raw.githubusercontent.com/Microsoft/dotnet/master/data/platforms.json";
     $.support.cors = true;
     $.getJSON( json, function( d ) {
 
@@ -75,7 +76,7 @@ $(document).ready(function() {
         $.each(data.platforms, function(key, val)
             {
 
-                if (val.category == "netfx")
+                if (val.category == "netfx" && val.popular)
                 {
                     //$("#versions").append("<li class=list-group-item><a href=" + val.runtime[0].link + ">" + val.platform + "</a></li>");
                     $("#versionsList").append("<a href='"+ val.runtime[0].link +"' class='install-tile'>"+ val.platform +"</a>");

--- a/target-dotnet-platforms.html
+++ b/target-dotnet-platforms.html
@@ -151,7 +151,12 @@ $(document).ready(function() {
             var row = generateRow(val, vs);
             var htmlRow = "<tr><td><a href='" + val.info + "'>" + val.platform +"</a></td>";
             if (category === "netfx") {
-                htmlRow += "<td>" + val.support + "</td>";
+                if (val.supportInfo.support === "Supported") {
+                    htmlRow += "<td>" + val.supportInfo.support + "</td>";
+                } else {
+                    htmlRow += "<td><a href='" + val.supportInfo.link + "'>" + val.supportInfo.support + "</a></td>";
+              
+                }
             }
             htmlRow += "<td>" + row + "</td></tr>";
             console.log(htmlRow);


### PR DESCRIPTION
The fixes are:

* Filter out the download based on the "popular" key in the JSON
* Show the link for not supported platforms; the link goes to the blog post